### PR TITLE
Fix Apothecary fetch auth

### DIFF
--- a/frontend/src/pages/ApothecaryPage.jsx
+++ b/frontend/src/pages/ApothecaryPage.jsx
@@ -12,6 +12,7 @@ import {
   X,
 } from 'lucide-react';
 import FolderTree from '@/components/FolderTree.jsx';
+import api from '@/lib/api';
 
 function ApothecaryPage() {
   const [files, setFiles] = useState([]);
@@ -29,8 +30,7 @@ function ApothecaryPage() {
   const fetchFiles = useCallback(async () => {
     try {
       setIsLoading(true);
-      const response = await fetch('http://localhost:5000/api/files/structure');
-      const data = await response.json();
+      const { data } = await api.get('/api/files/structure');
       setFiles(data.categories || []);
     } catch (error) {
       console.error('Error fetching files:', error);
@@ -85,21 +85,13 @@ function ApothecaryPage() {
 
     try {
       setUploadProgress(0);
-      const response = await fetch('http://localhost:5000/api/files/upload', {
-        method: 'POST',
-        body: formData,
-      });
-
-      if (response.ok) {
-        setUploadProgress(100);
-        setTimeout(() => {
-          setShowUploadModal(false);
-          setUploadProgress(0);
-          fetchFiles();
-        }, 1000);
-      } else {
-        throw new Error('Upload failed');
-      }
+      await api.post('/api/files/upload', formData);
+      setUploadProgress(100);
+      setTimeout(() => {
+        setShowUploadModal(false);
+        setUploadProgress(0);
+        fetchFiles();
+      }, 1000);
     } catch (error) {
       console.error('Upload error:', error);
       alert('Σφάλμα κατά το ανέβασμα του αρχείου');
@@ -110,24 +102,13 @@ function ApothecaryPage() {
     if (!newFolderName.trim()) return;
 
     try {
-      const response = await fetch('http://localhost:5000/api/folders/create', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          name: newFolderName,
-          parentFolder: '', // Creating at root for now
-        }),
+      await api.post('/api/folders/create', {
+        name: newFolderName,
+        parentFolder: '', // Creating at root for now
       });
-
-      if (response.ok) {
-        setShowFolderModal(false);
-        setNewFolderName('');
-        fetchFiles();
-      } else {
-        throw new Error('Folder creation failed');
-      }
+      setShowFolderModal(false);
+      setNewFolderName('');
+      fetchFiles();
     } catch (error) {
       console.error('Create folder error:', error);
       alert('Σφάλμα κατά τη δημιουργία του φακέλου');

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx';
 import { Button } from '@/components/ui/button.jsx';
 import { Badge } from '@/components/ui/badge.jsx';
-import { 
+import {
   Files, 
   MessageSquare, 
   Bot, 
@@ -14,6 +14,7 @@ import {
   FileText,
   ArrowRight
 } from 'lucide-react';
+import api from '@/lib/api';
 
 function HomePage() {
   const [stats, setStats] = useState({
@@ -28,16 +29,13 @@ function HomePage() {
     const fetchStats = async () => {
       try {
         // Fetch file structure
-        const filesResponse = await fetch('http://localhost:5000/api/files/structure');
-        const filesData = await filesResponse.json();
-        
+        const { data: filesData } = await api.get('/api/files/structure');
+
         // Fetch forum discussions
-        const discussionsResponse = await fetch('http://localhost:5000/api/discussions');
-        const discussionsData = await discussionsResponse.json();
-        
+        const { data: discussionsData } = await api.get('/api/discussions');
+
         // Fetch categories
-        const categoriesResponse = await fetch('http://localhost:5000/api/categories');
-        const categoriesData = await categoriesResponse.json();
+        const { data: categoriesData } = await api.get('/api/categories');
 
         setStats({
           totalFiles: filesData.metadata?.total_files || 0,


### PR DESCRIPTION
## Summary
- ensure Apothecary and Home pages use axios API client
- this attaches the JWT so `/api/files/structure` works

## Testing
- `pnpm lint` *(fails: Request was cancelled - network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6875e88ddd8c832580b67487b63aacab